### PR TITLE
fix: distortion effect sequencing (backgrounds no longer shrink forever)

### DIFF
--- a/src/capture.js
+++ b/src/capture.js
@@ -11,19 +11,20 @@ import { SNES_WIDTH, SNES_HEIGHT, renderLayers } from "./engine";
     - palette cycling is advanced once per rendered frame (call-count driven)
   so the exact length of a perfect loop can be computed in closed form instead
   of guessed. For one layer:
-    - distortion repeats every  120 / gcd(speed, 120)  ticks
-      (the π/60 constant in Distorter means 120 ticks == one full 2π sweep at
-      speed 1); in rendered frames that's  ticks / gcd(ticks, frameSkip).
+    - a background's distortion is a sequence of effects, each active for its
+      `duration` (measured in game frames, two per engine tick), looping once
+      the last duration elapses; the whole distortion state is a pure function
+      of the position within that cycle, so it repeats every
+      cycle / gcd(cycle, 2 * frameSkip) rendered frames. An effect with a zero
+      duration is never switched away from, and its scroll phase realigns
+      every  120 / gcd(speed, 120)  ticks (the π/60 constant in Distorter
+      means 120 ticks == one full 2π sweep at speed 1); anything played before
+      it is a one-shot intro that the warmup has to skip.
     - palette cycling repeats every  interval * modulus  frames, where
       interval = ceil(paletteCycleSpeed / 2) and modulus is the cycle length
       (or its lcm / doubled length for the two-cycle and ping-pong types).
   A single layer's loop is the lcm of those two; the whole scene is the lcm
   across both visible layers.
-
-  A handful of backgrounds use distortion *acceleration* (frequency/amplitude/
-  compression that grow with time). Those never return to their starting state
-  in this engine, so they can't loop seamlessly; we fall back to the palette
-  loop length and flag it.
 */
 
 const MAX_FRAMES = 1800; // safety cap (~60s at 30fps) to bound file size
@@ -44,12 +45,40 @@ function lcm(a, b) {
   return Math.abs(Math.trunc(a / gcd(a, b)) * b);
 }
 
-/* Number of rendered frames before the distortion realigns. */
-function distortionFrames(effect, frameSkip) {
+/* Number of rendered frames before a single effect's scroll phase realigns. */
+function speedFrames(effect, frameSkip) {
   const speed = effect ? Math.abs(Math.trunc(effect.speed)) : 0;
   if (speed === 0) return 1;
   const ticks = 120 / gcd(speed, 120);
   return ticks / gcd(ticks, frameSkip);
+}
+
+/* Loop length (in rendered frames) and required warmup for a layer's effect
+   sequence; see the header comment. */
+function distortionInfo(effects, frameSkip) {
+  if (!effects || effects.length === 0) {
+    return { frames: 1, warmup: 0, notSeamless: false };
+  }
+  let cycle = 0;
+  for (const effect of effects) {
+    if (effect.duration === 0) {
+      return {
+        frames: speedFrames(effect, frameSkip),
+        warmup: Math.ceil(cycle / (2 * frameSkip)),
+        notSeamless: hasAcceleration(effect),
+      };
+    }
+    cycle += effect.duration;
+  }
+  const still =
+    effects.length === 1 &&
+    !hasAcceleration(effects[0]) &&
+    Math.trunc(effects[0].speed) === 0;
+  return {
+    frames: still ? 1 : cycle / gcd(cycle, 2 * frameSkip),
+    warmup: 0,
+    notSeamless: false,
+  };
 }
 
 /* Number of rendered frames before the palette cycle returns to its start. */
@@ -72,10 +101,10 @@ function paletteFrames(pc) {
 }
 
 function hasAcceleration(effect) {
-  // Any non-zero acceleration makes amplitude/frequency/compression grow with
-  // the tick count, so the distortion never returns to its start — even when
-  // the base speed is 0 (the sine still has no period because its envelope
-  // keeps changing).
+  // Non-zero acceleration makes amplitude/frequency/compression grow with the
+  // tick count. Inside a looping sequence that's bounded (the clock resets
+  // when the sequence cycles), but a pinned zero-duration effect runs on one
+  // clock forever, so an accelerating one never returns to its start.
   return (
     !!effect &&
     (effect.frequencyAcceleration !== 0 ||
@@ -97,6 +126,7 @@ export function computeLoop(engine) {
   let total = 1;
   let colorPeriod = 1;
   let maxInterval = 1;
+  let distortionWarmup = 0;
   let notSeamless = false;
   const contributing = [];
 
@@ -106,23 +136,25 @@ export function computeLoop(engine) {
     if (!layer || !layer.entry || !(alpha[i] > 0)) continue;
     contributing.push(i);
 
-    const effect = layer.distorter && layer.distorter.effect;
+    const effects = (layer.distorter && layer.distorter.effects) || [];
     const pc = layer.paletteCycle;
     const pf = paletteFrames(pc);
-    const df = distortionFrames(effect, frameSkip);
+    const dInfo = distortionInfo(effects, frameSkip);
 
     colorPeriod = lcm(colorPeriod, pf);
-    total = lcm(total, lcm(df, pf));
+    total = lcm(total, lcm(dInfo.frames, pf));
     if (pc && pc.speed)
       maxInterval = Math.max(maxInterval, Math.ceil(pc.speed));
-    if (hasAcceleration(effect)) notSeamless = true;
+    distortionWarmup = Math.max(distortionWarmup, dInfo.warmup);
+    if (dInfo.notSeamless) notSeamless = true;
   }
 
   // The palette holds its first arrangement for 2*interval-1 frames (the first
   // cycle() fire is a no-op at position 0), versus `interval` frames in steady
   // state. Rendering from a fresh state therefore can't loop; warm past that
-  // transient so the captured window is purely periodic.
-  const warmup = 2 * maxInterval;
+  // transient — and past any one-shot distortion intro — so the captured
+  // window is purely periodic.
+  const warmup = Math.max(2 * maxInterval, distortionWarmup);
 
   const trueLength = notSeamless ? Infinity : total;
 

--- a/src/rom/background_layer.js
+++ b/src/rom/background_layer.js
@@ -1,62 +1,74 @@
-import BackgroundGraphics from './background_graphics'
-import BackgroundPalette from './background_palette'
-import DistortionEffect from './distortion_effect'
-import BattleBackground from './battle_background'
-import Distorter from './distorter'
-import PaletteCycle from './palette_cycle'
-const [WIDTH, HEIGHT] = [256, 256]
+import BackgroundGraphics from "./background_graphics";
+import BackgroundPalette from "./background_palette";
+import DistortionEffect from "./distortion_effect";
+import BattleBackground from "./battle_background";
+import Distorter from "./distorter";
+import PaletteCycle from "./palette_cycle";
+const [WIDTH, HEIGHT] = [256, 256];
 export default class BackgroundLayer {
-  constructor (entry, rom) {
-    this.rom = rom
-    this.graphics = null
-    this.paletteCycle = null
-    this.pixels = new Int16Array(WIDTH * HEIGHT * 4)
-    this.distorter = new Distorter(this.pixels)
-    this.loadEntry(entry)
+  constructor(entry, rom) {
+    this.rom = rom;
+    this.graphics = null;
+    this.paletteCycle = null;
+    this.pixels = new Int16Array(WIDTH * HEIGHT * 4);
+    this.distorter = new Distorter(this.pixels);
+    this.loadEntry(entry);
   }
   /**
-  * Renders a frame of the background animation into the specified Bitmap
-  *
-  * @param dst
-  *            Bitmap object into which to render
-  * @param letterbox
-  *            Size in pixels of black borders at top and bottom of image
-  * @param ticks
-  *            Time value of the frame to compute
-  * @param alpha
-  *            Blending opacity
-  * @param erase
-  *            Whether or not to clear the destination bitmap before
-  *            rendering
-  */
-  overlayFrame (bitmap, letterbox, ticks, alpha, erase) {
+   * Renders a frame of the background animation into the specified Bitmap
+   *
+   * @param dst
+   *            Bitmap object into which to render
+   * @param letterbox
+   *            Size in pixels of black borders at top and bottom of image
+   * @param ticks
+   *            Time value of the frame to compute
+   * @param alpha
+   *            Blending opacity
+   * @param erase
+   *            Whether or not to clear the destination bitmap before
+   *            rendering
+   */
+  overlayFrame(bitmap, letterbox, ticks, alpha, erase) {
     if (this.paletteCycle !== null) {
-      this.paletteCycle.cycle()
-      this.graphics.draw(this.pixels, this.paletteCycle)
+      this.paletteCycle.cycle();
+      this.graphics.draw(this.pixels, this.paletteCycle);
     }
-    return this.distorter.overlayFrame(bitmap, letterbox, ticks, alpha, erase)
+    return this.distorter.overlayFrame(bitmap, letterbox, ticks, alpha, erase);
   }
-  loadGraphics (index) {
-    this.graphics = this.rom.getObject(BackgroundGraphics, index)
+  loadGraphics(index) {
+    this.graphics = this.rom.getObject(BackgroundGraphics, index);
   }
-  loadPalette (background) {
+  loadPalette(background) {
     this.paletteCycle = new PaletteCycle({
       background,
-      palette: this.rom.getObject(BackgroundPalette, background.paletteIndex)
-    })
+      palette: this.rom.getObject(BackgroundPalette, background.paletteIndex),
+    });
   }
-  loadEffect (index) {
-    this.distorter.effect = new DistortionEffect(index)
+  loadEffects(indices) {
+    /* A null (zero) first slot passes control to the second slot; a null slot anywhere after that truncates the sequence (e.g. entry 227's slots are [120, 121, 0, 114], and only the first two are ever played) */
+    let slots = indices[0] === 0 ? indices.slice(1) : indices;
+    const firstNull = slots.indexOf(0);
+    if (firstNull !== -1) {
+      slots = slots.slice(0, firstNull);
+    }
+    if (slots.length === 0) {
+      slots = [0];
+    }
+    this.distorter.effects = slots.map((index) => new DistortionEffect(index));
   }
-  loadEntry (index) {
-    this.entry = index
-    const background = this.rom.getObject(BattleBackground, index)
+  loadEntry(index) {
+    this.entry = index;
+    const background = this.rom.getObject(BattleBackground, index);
     /* Set graphics/palette */
-    this.loadGraphics(background.graphicsIndex)
-    this.loadPalette(background)
-    const animation = background.animation
-    const e1 = (animation >> 24) & 0xFF
-    const e2 = (animation >> 16) & 0xFF
-    this.loadEffect(e2 || e1)
+    this.loadGraphics(background.graphicsIndex);
+    this.loadPalette(background);
+    const animation = background.animation;
+    this.loadEffects([
+      (animation >> 24) & 0xff,
+      (animation >> 16) & 0xff,
+      (animation >> 8) & 0xff,
+      animation & 0xff,
+    ]);
   }
 }

--- a/src/rom/distorter.js
+++ b/src/rom/distorter.js
@@ -1,35 +1,28 @@
-import { HORIZONTAL, HORIZONTAL_INTERLACED, VERTICAL } from './distortion_effect'
-import { SNES_WIDTH, SNES_HEIGHT } from '../engine'
-const { PI: π, sin, round, floor } = Math
-const R = 0
-const G = 1
-const B = 2
-const A = 3
-function mod (n, m) {
-  return ((n % m) + m) % m
+import {
+  HORIZONTAL,
+  HORIZONTAL_INTERLACED,
+  VERTICAL,
+  asInt16,
+} from "./distortion_effect";
+import { SNES_WIDTH, SNES_HEIGHT } from "../engine";
+const { PI: π, sin, round, floor } = Math;
+const R = 0;
+const G = 1;
+const B = 2;
+const A = 3;
+function mod(n, m) {
+  return ((n % m) + m) % m;
 }
 export default class Distorter {
-  constructor (bitmap) {
-    // There is some redundancy here: 'effect' is currently what is used
-    // in computing frames, although really there should be a list of
-    // four different effects ('dist') which are used in sequence.
-    //
-    // 'distortions' is currently unused, but ComputeFrame should be changed to
-    // make use of it as soon as the precise nature of effect sequencing
-    // can be determined.
-    //
-    // The goal is to make Distorter a general-purpose BG effect class that
-    // can be used to show either a single distortion effect, or to show the
-    // entire sequence of effects associated with a background entry (including
-    // scrolling and Palette animation, which still need to be implemented).
-    //     this.distortions = Array(4).fill(new DistortionEffect());
-    this.bitmap = bitmap
-    /* NOTE: Another discrepancy from Java: These values should be "short" and must have a specific precision. This seems to affect backgrounds with distortEffect === HORIZONTAL */
-    this.C1 = 1 / 512
-    this.C2 = 8 * π / (1024 * 256)
-    this.C3 = π / 60
+  constructor(bitmap) {
+    this.bitmap = bitmap;
+    /* The sequence of up to four DistortionEffects associated with a background entry; see effectState() for how they are cycled */
+    this.effects = [];
+    this.C1 = 1 / 512;
+    this.C2 = (8 * π) / (1024 * 256);
+    this.C3 = π / 60;
   }
-  setOffsetConstants (ticks, effect) {
+  setOffsetConstants(ticks, effect) {
     const {
       amplitude,
       amplitudeAcceleration,
@@ -37,106 +30,155 @@ export default class Distorter {
       compressionAcceleration,
       frequency,
       frequencyAcceleration,
-      speed
-    } = effect
-    /* Compute "current" values of amplitude, frequency and compression */
-    const t2 = ticks * 2
-    this.amplitude = this.C1 * (amplitude + amplitudeAcceleration * t2)
-    this.frequency = this.C2 * (frequency + (frequencyAcceleration * t2))
-    this.compression = 1 + (compression + (compressionAcceleration * t2)) / 256
-    this.speed = this.C3 * speed * ticks
-    this.S = y => round(this.amplitude * sin(this.frequency * y + this.speed))
-  }
-  overlayFrame (dst, letterbox, ticks, alpha, erase) {
-    return this.computeFrame(dst, this.bitmap, letterbox, ticks, alpha, erase, this.effect)
+      speed,
+    } = effect;
+    /* Compute "current" values of amplitude, frequency and compression.
+       The SNES accumulates these in 16-bit registers, so they wrap around;
+       the paired effects in the ROM rely on that wraparound to line up
+       seamlessly (e.g. one effect ends its amplitude ramp at 80 * 500 = 40000,
+       which wraps to -25536 — exactly where its partner effect begins). */
+    const t2 = ticks * 2;
+    this.amplitude = this.C1 * asInt16(amplitude + amplitudeAcceleration * t2);
+    this.frequency = this.C2 * asInt16(frequency + frequencyAcceleration * t2);
+    this.compression =
+      1 + asInt16(compression + compressionAcceleration * t2) / 256;
+    this.speed = this.C3 * speed * ticks;
+    this.S = (y) =>
+      round(this.amplitude * sin(this.frequency * y + this.speed));
   }
   /**
-  * Evaluates the distortion effect at the given destination line and
-  * time value and returns the computed offset value.
-  * If the distortion mode is horizontal, this offset should be interpreted
-  * as the number of pixels to offset the given line's starting x position.
-  * If the distortion mode is vertical, this offset should be interpreted as
-  * the y-coordinate of the line from the source bitmap to draw at the given
-  * y-coordinate in the destination bitmap.
-  * @param y
-  *   The y-coordinate of the destination line to evaluate for
-  * @param t
-  *   The number of ticks since beginning animation
-  * @return
-  *   The distortion offset for the given (y, t) coordinates
-  */
-  getAppliedOffset (y, distortionEffect) {
-    const s = this.S(y)
+   * Selects which effect of the background's sequence is active at the given
+   * time, and how long it has been active. Durations are measured in game
+   * frames, two per engine tick (the same doubling as t2 in
+   * setOffsetConstants). Each effect's clock restarts when it becomes active,
+   * and the sequence repeats once the last effect's duration elapses — this
+   * looping is what keeps accelerating effects (e.g. the Giygas backgrounds)
+   * from distorting indefinitely. An effect with a zero duration is never
+   * switched away from.
+   * @param ticks
+   *   The number of engine ticks since beginning animation
+   * @return
+   *   A [effect, ticks] pair: the active effect and its local tick value
+   */
+  effectState(ticks) {
+    const effects = this.effects;
+    if (effects.length === 0) {
+      return [this.effect, ticks];
+    }
+    let t = ticks * 2;
+    let cycle = 0;
+    let terminal = null;
+    for (const effect of effects) {
+      if (effect.duration === 0) {
+        terminal = effect;
+        break;
+      }
+      cycle += effect.duration;
+    }
+    if (terminal === null) {
+      t = mod(t, cycle);
+    } else if (t >= cycle) {
+      return [terminal, (t - cycle) / 2];
+    }
+    for (const effect of effects) {
+      if (t < effect.duration) {
+        return [effect, t / 2];
+      }
+      t -= effect.duration;
+    }
+    return [effects[0], t / 2];
+  }
+  overlayFrame(dst, letterbox, ticks, alpha, erase) {
+    const [effect, effectTicks] = this.effectState(ticks);
+    return this.computeFrame(
+      dst,
+      this.bitmap,
+      letterbox,
+      effectTicks,
+      alpha,
+      erase,
+      effect,
+    );
+  }
+  /**
+   * Evaluates the distortion effect at the given destination line and
+   * time value and returns the computed offset value.
+   * If the distortion mode is horizontal, this offset should be interpreted
+   * as the number of pixels to offset the given line's starting x position.
+   * If the distortion mode is vertical, this offset should be interpreted as
+   * the y-coordinate of the line from the source bitmap to draw at the given
+   * y-coordinate in the destination bitmap.
+   * @param y
+   *   The y-coordinate of the destination line to evaluate for
+   * @param t
+   *   The number of ticks since beginning animation
+   * @return
+   *   The distortion offset for the given (y, t) coordinates
+   */
+  getAppliedOffset(y, distortionEffect) {
+    const s = this.S(y);
     switch (distortionEffect) {
       default:
       case HORIZONTAL:
-        return s
+        return s;
       case HORIZONTAL_INTERLACED:
-        return y % 2 === 0 ? -s : s
+        return y % 2 === 0 ? -s : s;
       case VERTICAL:
         /* Compute L */
-        return mod(floor(s + y * this.compression), 256)
+        return mod(floor(s + y * this.compression), 256);
     }
   }
-  computeFrame (destinationBitmap, sourceBitmap, letterbox, ticks, alpha, erase, effect) {
-    const { type: distortionEffect } = effect
-    const newBitmap = destinationBitmap
-    const oldBitmap = sourceBitmap
+  computeFrame(
+    destinationBitmap,
+    sourceBitmap,
+    letterbox,
+    ticks,
+    alpha,
+    erase,
+    effect,
+  ) {
+    const { type: distortionEffect } = effect;
+    const newBitmap = destinationBitmap;
+    const oldBitmap = sourceBitmap;
     /* TODO: Hardcoing is bad */
-    const dstStride = 1024
-    const srcStride = 1024
-    /*
-      Given the list of 4 distortions and the tick count, decide which
-      effect to use:
-      Basically, we have 4 effects, each possibly with a duration.
-      Evaluation order is: 1, 2, 3, 0
-      If the first effect is null, control transitions to the second effect.
-      If the first and second effects are null, no effect occurs.
-      If any other effect is null, the sequence is truncated.
-      If a non-null effect has a zero duration, it will not be switched
-      away from.
-      Essentially, this configuration sets up a precise and repeating
-      sequence of between 0 and 4 different distortion effects. Once we
-      compute the sequence, computing the particular frame of which distortion
-      to use becomes easy; simply mod the tick count by the total duration
-      of the effects that are used in the sequence, then check the remainder
-      against the cumulative durations of each effect.
-      I guess the trick is to be sure that my description above is correct.
-      Heh.
-    */
-    let x, y, bPos, sPos, dx
-    this.setOffsetConstants(ticks, effect)
+    const dstStride = 1024;
+    const srcStride = 1024;
+    let x, y, bPos, sPos, dx;
+    this.setOffsetConstants(ticks, effect);
     for (y = 0; y < SNES_HEIGHT; ++y) {
-      const offset = this.getAppliedOffset(y, distortionEffect)
-      const L = distortionEffect === VERTICAL ? offset : y
+      const offset = this.getAppliedOffset(y, distortionEffect);
+      const L = distortionEffect === VERTICAL ? offset : y;
       for (x = 0; x < SNES_WIDTH; ++x) {
-        bPos = x * 4 + y * dstStride
+        bPos = x * 4 + y * dstStride;
         if (y < letterbox || y > SNES_HEIGHT - letterbox) {
-          newBitmap[bPos + R] = 0
-          newBitmap[bPos + G] = 0
-          newBitmap[bPos + B] = 0
-          newBitmap[bPos + A] = 255
-          continue
+          newBitmap[bPos + R] = 0;
+          newBitmap[bPos + G] = 0;
+          newBitmap[bPos + B] = 0;
+          newBitmap[bPos + A] = 255;
+          continue;
         }
-        dx = x
-        if (distortionEffect === HORIZONTAL || distortionEffect === HORIZONTAL_INTERLACED) {
-          dx = mod(x + offset, SNES_WIDTH)
+        dx = x;
+        if (
+          distortionEffect === HORIZONTAL ||
+          distortionEffect === HORIZONTAL_INTERLACED
+        ) {
+          dx = mod(x + offset, SNES_WIDTH);
         }
-        sPos = dx * 4 + L * srcStride
+        sPos = dx * 4 + L * srcStride;
         /* Either copy or add to the destination bitmap */
         if (erase) {
-          newBitmap[bPos + R] = alpha * oldBitmap[sPos + R]
-          newBitmap[bPos + G] = alpha * oldBitmap[sPos + G]
-          newBitmap[bPos + B] = alpha * oldBitmap[sPos + B]
-          newBitmap[bPos + A] = 255
+          newBitmap[bPos + R] = alpha * oldBitmap[sPos + R];
+          newBitmap[bPos + G] = alpha * oldBitmap[sPos + G];
+          newBitmap[bPos + B] = alpha * oldBitmap[sPos + B];
+          newBitmap[bPos + A] = 255;
         } else {
-          newBitmap[bPos + R] += alpha * oldBitmap[sPos + R]
-          newBitmap[bPos + G] += alpha * oldBitmap[sPos + G]
-          newBitmap[bPos + B] += alpha * oldBitmap[sPos + B]
-          newBitmap[bPos + A] = 255
+          newBitmap[bPos + R] += alpha * oldBitmap[sPos + R];
+          newBitmap[bPos + G] += alpha * oldBitmap[sPos + G];
+          newBitmap[bPos + B] += alpha * oldBitmap[sPos + B];
+          newBitmap[bPos + A] = 255;
         }
       }
     }
-    return newBitmap
+    return newBitmap;
   }
 }

--- a/src/rom/distortion_effect.js
+++ b/src/rom/distortion_effect.js
@@ -1,15 +1,15 @@
-import { readBlock } from './rom'
-export const HORIZONTAL = 1
-export const HORIZONTAL_INTERLACED = 2
-export const VERTICAL = 3
+import { readBlock } from "./rom";
+export const HORIZONTAL = 1;
+export const HORIZONTAL_INTERLACED = 2;
+export const VERTICAL = 3;
 /* The data in effects is stored as uint8, but when we compute with them, we need to cast the results to int16. */
-function asInt16 (value) {
-  return new Int16Array([value])[0]
+export function asInt16(value) {
+  return new Int16Array([value])[0];
 }
 export default class DistortionEffect {
-  constructor (index = 0) {
-    this.data = new Uint8Array(17)
-    this.read(index)
+  constructor(index = 0) {
+    this.data = new Uint8Array(17);
+    this.read(index);
   }
   /* Is not caching distortion effects doing any harm? */
   //   static handler() {
@@ -17,78 +17,81 @@ export default class DistortionEffect {
   //       ROM.add(new DistortionEffect(i));
   //     }
   //   }
-  static sanitize (type) {
+  static sanitize(type) {
     if (type !== HORIZONTAL && type !== VERTICAL) {
-      return HORIZONTAL_INTERLACED
+      return HORIZONTAL_INTERLACED;
     } else {
-      return type
+      return type;
     }
   }
-  get type () {
-    return DistortionEffect.sanitize(this.data[2])
+  get type() {
+    return DistortionEffect.sanitize(this.data[2]);
   }
-  set type (value) {
-    this.data[2] = DistortionEffect.sanitize(this.data[2])
+  set type(value) {
+    this.data[2] = DistortionEffect.sanitize(this.data[2]);
   }
-  //   get duration() {
-  //     return asInt16(this.data[0] + (this.data[1] << 8));
-  //   }
-  //   set duration(value) {
-  //     this.data[0] = value;
-  //     this.data[1] = value >> 8;
-  //   }
-  get frequency () {
-    return asInt16(this.data[3] + (this.data[4] << 8))
+  /* Duration is measured in game frames (two per engine tick) and is unsigned;
+  a zero duration means the effect is never switched away from */
+  get duration() {
+    return this.data[0] + (this.data[1] << 8);
   }
-  set frequency (value) {
-    this.data[3] = value
-    this.data[4] = value >> 8
+  set duration(value) {
+    this.data[0] = value;
+    this.data[1] = value >> 8;
   }
-  get amplitude () {
-    return asInt16(this.data[5] + (this.data[6] << 8))
+
+  get frequency() {
+    return asInt16(this.data[3] + (this.data[4] << 8));
   }
-  set amplitude (value) {
-    this.data[5] = value
-    this.data[6] = value >> 8
+  set frequency(value) {
+    this.data[3] = value;
+    this.data[4] = value >> 8;
   }
-  get compression () {
-    return asInt16(this.data[8] + (this.data[9] << 8))
+  get amplitude() {
+    return asInt16(this.data[5] + (this.data[6] << 8));
   }
-  set compression (value) {
-    this.data[8] = value
-    this.data[9] = value >> 8
+  set amplitude(value) {
+    this.data[5] = value;
+    this.data[6] = value >> 8;
   }
-  get frequencyAcceleration () {
-    return asInt16(this.data[10] + (this.data[11] << 8))
+  get compression() {
+    return asInt16(this.data[8] + (this.data[9] << 8));
   }
-  set frequencyAcceleration (value) {
-    this.data[10] = value
-    this.data[11] = value >> 8
+  set compression(value) {
+    this.data[8] = value;
+    this.data[9] = value >> 8;
   }
-  get amplitudeAcceleration () {
-    return asInt16(this.data[12] + (this.data[13] << 8))
+  get frequencyAcceleration() {
+    return asInt16(this.data[10] + (this.data[11] << 8));
   }
-  set amplitudeAcceleration (value) {
-    this.data[12] = value
-    this.data[13] = value >> 8
+  set frequencyAcceleration(value) {
+    this.data[10] = value;
+    this.data[11] = value >> 8;
   }
-  get speed () {
-    return asInt16(this.data[14])
+  get amplitudeAcceleration() {
+    return asInt16(this.data[12] + (this.data[13] << 8));
   }
-  set speed (value) {
-    this.data[14] = value
+  set amplitudeAcceleration(value) {
+    this.data[12] = value;
+    this.data[13] = value >> 8;
   }
-  get compressionAcceleration () {
-    return asInt16(this.data[15] + (this.data[16] << 8))
+  get speed() {
+    return asInt16(this.data[14]);
   }
-  set compressionAcceleration (value) {
-    this.data[15] = value
-    this.data[16] = value >> 8
+  set speed(value) {
+    this.data[14] = value;
   }
-  read (index) {
-    const main = readBlock(0xF708 + index * 17)
+  get compressionAcceleration() {
+    return asInt16(this.data[15] + (this.data[16] << 8));
+  }
+  set compressionAcceleration(value) {
+    this.data[15] = value;
+    this.data[16] = value >> 8;
+  }
+  read(index) {
+    const main = readBlock(0xf708 + index * 17);
     for (let i = 0; i < 17; ++i) {
-      this.data[i] = main.readInt16()
+      this.data[i] = main.readInt16();
     }
   }
 }


### PR DESCRIPTION
## Problem

Backgrounds using accelerating distortion effects (43, 86, 110, the Giygas backgrounds) distort in one direction forever instead of looping like the real game. The [Abstract Art](https://github.com/gwhiteside/abstract-art) Android app renders these correctly.

## Cause

Each background entry stores up to four distortion effect indices (bytes 13–16 of its struct), and each effect has a duration (bytes 0–1). The game cycles through the sequence, restarting the effect clock at each switch. This port loaded a single effect (`e2 || e1`) and ran it on an unbounded tick, so acceleration deltas accumulated forever. Layer 110 is actually effect #93 (compression 512, delta −1, 512 frames) followed by #94 (compression 0, delta +1, 512 frames) — a seamless ping-pong the engine never played.

## Fix

- `DistortionEffect` exposes `duration` (previously commented out)
- `BackgroundLayer` loads the full slot sequence, honoring the original engine's rules: a null first slot passes control to the second; a later null slot truncates the sequence (this also fixes layer 227, whose slots `[120, 121, 0, 114]` should only ever play the first two — a case Abstract Art itself gets wrong)
- `Distorter.effectState()` picks the active effect from the tick, with per-effect clock resets, looping, and "zero duration = never switch away"
- Amplitude/frequency/compression accumulate through int16 like the SNES — every effect pair in the ROM seams exactly under 16-bit wraparound (e.g. #106 ends its amplitude ramp at 80·500 = 40000 → −25536, precisely #107's starting amplitude), which also resolves the old "these values should be short" note in `distorter.js`
- GIF capture computes loop length from the sequence cycle, so these backgrounds now export seamless GIFs instead of falling back to the palette-only loop

Fixes #33
